### PR TITLE
feat: add zip_ext_count_symlinks

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -161,6 +161,7 @@ SET(LIBZIP_SOURCES
   zip_unchange_archive.c
   zip_unchange_data.c
   zip_utf-8.c
+  zip_ext_count_symlinks.c
 )
 
 IF(WIN32)

--- a/lib/zip.h
+++ b/lib/zip.h
@@ -447,6 +447,8 @@ ZIP_EXTERN int zip_unchange(zip_t * _Nonnull, zip_uint64_t);
 ZIP_EXTERN int zip_unchange_all(zip_t * _Nonnull);
 ZIP_EXTERN int zip_unchange_archive(zip_t * _Nonnull);
 
+ZIP_EXTERN int zip_ext_count_symlinks(zip_t * _Nonnull);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/zip_ext_count_symlinks.c
+++ b/lib/zip_ext_count_symlinks.c
@@ -1,0 +1,26 @@
+#include "zipint.h"
+
+#define S_IFMT 0170000
+#define S_IFLNK 0120000
+
+ZIP_EXTERN int
+zip_ext_count_symlinks(zip_t *za) {
+    int count = 0;
+
+    zip_uint64_t i;
+    zip_uint8_t opsys;
+    zip_uint32_t attributes;
+
+    for (i = 0; i < za->nentry; i++) {
+        int attrs = zip_file_get_external_attributes(za, i, 0, &opsys, &attributes);
+        if (attrs == -1) {
+            return -1;
+        }
+
+        if (opsys == ZIP_OPSYS_UNIX && ((attributes >> 16) & S_IFMT) == S_IFLNK) {
+            count++;
+        }
+    }
+
+    return count;
+}


### PR DESCRIPTION
**What's the problem this PR addresses?**

Need an efficient way to get the amount of symlinks in a zip archive for optimizations in yarn

**How did you fix it?**

Added `zip_ext_count_symlinks` that returns the amount of symlinks in the archive